### PR TITLE
ページのコンポーネント全体の上下に余白を追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,10 +9,14 @@ import TopPage from './TopPage.vue';
   </header>
 
   <main>
-    <TopPage />
+    <div class="Component">
+      <TopPage />
+    </div>
   </main>
 </template>
 
 <style scoped>
-
+.Component {
+  margin: 50px 0;
+}
 </style>

--- a/src/components/BigIcon.vue
+++ b/src/components/BigIcon.vue
@@ -9,6 +9,5 @@
     height: 270px;
     justify-content: center;
     align-items: center;
-    margin-top: 50px;
 }
 </style>


### PR DESCRIPTION
# 目的

* ページ本体の上部分の Navigation との距離を統一したい
* ページ下に余白がほしい (特にスマホだとギリギリになるので)
